### PR TITLE
PATCH /applications/{id} で存在しないidを指定した場合の挙動を修正

### DIFF
--- a/fake/applications.go
+++ b/fake/applications.go
@@ -231,19 +231,19 @@ func (engine *Engine) PatchApplication(id string, reqBody *v1.PatchApplicationBo
 					app.Components = &components
 				}
 			}
-		}
 
-		updatedAt := time.Now().UTC().Truncate(time.Second)
-		patchedApp = v1.HandlerPatchApplication{
-			Name:           app.Name,
-			TimeoutSeconds: app.TimeoutSeconds,
-			Port:           app.Port,
-			MinScale:       app.MinScale,
-			MaxScale:       app.MaxScale,
-			Components:     app.Components,
-			Status:         (*v1.HandlerPatchApplicationStatus)(app.Status),
-			PublicUrl:      app.PublicUrl,
-			UpdatedAt:      &updatedAt,
+			updatedAt := time.Now().UTC().Truncate(time.Second)
+			patchedApp = v1.HandlerPatchApplication{
+				Name:           app.Name,
+				TimeoutSeconds: app.TimeoutSeconds,
+				Port:           app.Port,
+				MinScale:       app.MinScale,
+				MaxScale:       app.MaxScale,
+				Components:     app.Components,
+				Status:         (*v1.HandlerPatchApplicationStatus)(app.Status),
+				PublicUrl:      app.PublicUrl,
+				UpdatedAt:      &updatedAt,
+			}
 		}
 	}
 


### PR DESCRIPTION
PATCH /applications/{id} で存在しないidを指定した場合に、存在しないidのapplicationが変更されたかのようなレスポンスが帰ってきてしまう挙動を修正しました。