### PR TITLE
エラーハンドリングの実装

### DIFF
--- a/apis/v1/errors.go
+++ b/apis/v1/errors.go
@@ -1,0 +1,68 @@
+// Copyright 2021-2024 The sacloud/apprun-api-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"fmt"
+	"strings"
+)
+
+var (
+	_ error = (*ModelDefaultError)(nil)
+)
+
+func (e ModelDefaultError) Error() string {
+	var in string
+	if len(*e.Detail.Errors) == 0 {
+		in = "(empty)"
+	} else {
+		var errorStrings []string
+		for _, err := range *e.Detail.Errors {
+			errorStrings = append(errorStrings, fmt.Sprintf("{%s}", err.String()))
+		}
+
+		in = strings.Join(errorStrings, ", ")
+	}
+
+	return fmt.Sprintf("code: %d, message: %s, inner_error: %s", e.Detail.Code, *e.Detail.Message, in)
+}
+
+// String Stringer実装
+func (e ModelError) String() string {
+	var domain, reason, message, locationType, location string
+	if e.Domain != nil {
+		domain = *e.Domain
+	}
+	if e.Reason != nil {
+		reason = *e.Reason
+	}
+	if e.Message != nil {
+		message = *e.Message
+	}
+	if e.LocationType != nil {
+		locationType = string(*e.LocationType)
+	}
+	if e.Location != nil {
+		location = *e.Location
+	}
+
+	return fmt.Sprintf("domain: %s, reason: %s, message: %s, location_type: %s, location: %s",
+		domain,
+		reason,
+		message,
+		locationType,
+		location,
+	)
+}

--- a/apis/v1/functions.go
+++ b/apis/v1/functions.go
@@ -1,0 +1,54 @@
+// Copyright 2021-2024 The sacloud/apprun-api-go authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+)
+
+func eCoalesce(errs ...interface{}) error {
+	for _, e := range errs {
+		if !(e == nil || reflect.ValueOf(e).IsNil()) {
+			return toError(e)
+		}
+	}
+	return nil
+}
+
+// toError errorまたはerrorResponserの実装からerrorを返す
+// 上記以外またはnilを渡した場合はpanicするため呼び出し側でチェックする必要がある
+func toError(v interface{}) error {
+	switch err := v.(type) {
+	case error:
+		return err
+	default:
+		msg := fmt.Sprintf("invalid arg: %#+v", v)
+		panic(msg)
+	}
+}
+
+var osStatusCodes = map[int]bool{
+	http.StatusOK:        true,
+	http.StatusCreated:   true,
+	http.StatusAccepted:  true,
+	http.StatusNoContent: true,
+}
+
+func isOKStatus(httpStatusCode int) bool {
+	_, ok := osStatusCodes[httpStatusCode]
+	return ok
+}

--- a/apis/v1/spec/codegen/client.yaml
+++ b/apis/v1/spec/codegen/client.yaml
@@ -1,4 +1,5 @@
 output: apis/v1/zz_client_gen.go
+templates: apis/v1/spec/codegen/templates
 generate:
   - client
 package: v1

--- a/apis/v1/spec/codegen/templates/client-with-responses.tmpl
+++ b/apis/v1/spec/codegen/templates/client-with-responses.tmpl
@@ -1,0 +1,129 @@
+// ClientWithResponses builds on ClientInterface to offer response payloads
+type ClientWithResponses struct {
+ClientInterface
+}
+
+// NewClientWithResponses creates a new ClientWithResponses, which wraps
+// Client with return type handling
+func NewClientWithResponses(server string, opts ...ClientOption) (*ClientWithResponses, error) {
+client, err := NewClient(server, opts...)
+if err != nil {
+return nil, err
+}
+return &ClientWithResponses{client}, nil
+}
+
+// WithBaseURL overrides the baseURL.
+func WithBaseURL(baseURL string) ClientOption {
+return func(c *Client) error {
+newBaseURL, err := url.Parse(baseURL)
+if err != nil {
+return err
+}
+c.Server = newBaseURL.String()
+return nil
+}
+}
+
+// ClientWithResponsesInterface is the interface specification for the client with responses above.
+type ClientWithResponsesInterface interface {
+{{range . -}}
+    {{$hasParams := .RequiresParamObject -}}
+    {{$pathParams := .PathParams -}}
+    {{$opid := .OperationId -}}
+    // {{$opid}} request{{if .HasBody}} with any body{{end}}
+    {{$opid}}{{if .HasBody}}WithBody{{end}}WithResponse(ctx context.Context{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params *{{$opid}}Params{{end}}{{if .HasBody}}, contentType string, body io.Reader{{end}}, reqEditors... RequestEditorFn) (*{{genResponseTypeName $opid}}, error)
+    {{range .Bodies}}
+        {{$opid}}{{.Suffix}}WithResponse(ctx context.Context{{genParamArgs $pathParams}}{{if $hasParams}}, params *{{$opid}}Params{{end}}, body {{$opid}}{{.NameTag}}RequestBody, reqEditors... RequestEditorFn) (*{{genResponseTypeName $opid}}, error)
+    {{end}}{{/* range .Bodies */}}
+{{end}}{{/* range . $opid := .OperationId */}}
+}
+
+{{range .}}{{$opid := .OperationId}}{{$op := .}}
+type {{$opid | ucFirst}}Response struct {
+Body         []byte
+HTTPResponse *http.Response
+{{- range getResponseTypeDefinitions .}}
+    {{.TypeName}} *{{.Schema.TypeDecl}}
+{{- end}}
+}
+
+// Status returns HTTPResponse.Status
+func (r {{$opid | ucFirst}}Response) Status() string {
+if r.HTTPResponse != nil {
+return r.HTTPResponse.Status
+}
+return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r {{$opid | ucFirst}}Response) StatusCode() int {
+if r.HTTPResponse != nil {
+return r.HTTPResponse.StatusCode
+}
+return 0
+}
+
+{{ $json20xType := "" }}{{ $json20xTypeName := "" }}{{ range getResponseTypeDefinitions . }}{{ if or (eq .TypeName "JSON200") (eq .TypeName "JSON201") }}{{ $json20xType = .Schema.TypeDecl }}{{ $json20xTypeName = .TypeName }}{{ end }}{{ end -}}
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r {{$opid | ucFirst}}Response) Result() ({{if $json20xType}}*{{ $json20xType}},{{end}}error) {
+    return {{if $json20xType}}r.{{ $json20xTypeName }}, {{end}}eCoalesce({{range getResponseTypeDefinitions .}}{{ if and (ne .TypeName "JSON200") (ne .TypeName "JSON201") }}r.{{.TypeName}},{{end}}{{end}}r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r {{$opid | ucFirst}}Response) UndefinedError() error {
+    if !isOKStatus(r.HTTPResponse.StatusCode){
+        return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+    }
+    return nil
+}
+{{end}}
+
+
+
+{{range .}}
+    {{$opid := .OperationId -}}
+    {{/* Generate client methods (with responses)*/}}
+
+    // {{$opid}}{{if .HasBody}}WithBody{{end}}WithResponse request{{if .HasBody}} with arbitrary body{{end}} returning *{{$opid}}Response
+    func (c *ClientWithResponses) {{$opid}}{{if .HasBody}}WithBody{{end}}WithResponse(ctx context.Context{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params *{{$opid}}Params{{end}}{{if .HasBody}}, contentType string, body io.Reader{{end}}, reqEditors... RequestEditorFn) (*{{genResponseTypeName $opid}}, error){
+    rsp, err := c.{{$opid}}{{if .HasBody}}WithBody{{end}}(ctx{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}}{{if .HasBody}}, contentType, body{{end}}, reqEditors...)
+    if err != nil {
+    return nil, err
+    }
+    return Parse{{genResponseTypeName $opid | ucFirst}}(rsp)
+    }
+
+    {{$hasParams := .RequiresParamObject -}}
+    {{$pathParams := .PathParams -}}
+    {{$bodyRequired := .BodyRequired -}}
+    {{range .Bodies}}
+        func (c *ClientWithResponses) {{$opid}}{{.Suffix}}WithResponse(ctx context.Context{{genParamArgs $pathParams}}{{if $hasParams}}, params *{{$opid}}Params{{end}}, body {{$opid}}{{.NameTag}}RequestBody, reqEditors... RequestEditorFn) (*{{genResponseTypeName $opid}}, error) {
+        rsp, err := c.{{$opid}}{{.Suffix}}(ctx{{genParamNames $pathParams}}{{if $hasParams}}, params{{end}}, body, reqEditors...)
+        if err != nil {
+        return nil, err
+        }
+        return Parse{{genResponseTypeName $opid | ucFirst}}(rsp)
+        }
+    {{end}}
+
+{{end}}{{/* operations */}}
+
+{{/* Generate parse functions for responses*/}}
+{{range .}}{{$opid := .OperationId}}
+
+// Parse{{genResponseTypeName $opid | ucFirst}} parses an HTTP response from a {{$opid}}WithResponse call
+func Parse{{genResponseTypeName $opid | ucFirst}}(rsp *http.Response) (*{{genResponseTypeName $opid}}, error) {
+bodyBytes, err := io.ReadAll(rsp.Body)
+defer func() { _ = rsp.Body.Close() }()
+if err != nil {
+return nil, err
+}
+
+response := {{genResponsePayload $opid}}
+
+{{genResponseUnmarshal .}}
+
+return response, nil
+}
+{{end}}{{/* range . $opid := .OperationId */}}

--- a/apis/v1/spec/openapi.yaml
+++ b/apis/v1/spec/openapi.yaml
@@ -1787,6 +1787,7 @@ components:
       type: object
       properties:
         error:
+          x-go-name: Detail
           type: object
           properties:
             code:
@@ -1800,30 +1801,32 @@ components:
     model.errors:
       type: array
       items:
-        type: object
-        properties:
-          domain:
-            type: string
-            example: global
-            nullable: true
-          reason:
-            type: string
-            example: required
-            nullable: true
-          message:
-            type: string
-            example: Login Required
-            nullable: true
-          location_type:
-            type: string
-            example: header
-            enum:
-              - header
-              - body
-              - query
-              - parameter
-            nullable: true
-          location:
-            type: string
-            example: Authorization
-            nullable: true
+        $ref: "#/components/schemas/model.error"
+    model.error:
+      type: object
+      properties:
+        domain:
+          type: string
+          example: global
+          nullable: true
+        reason:
+          type: string
+          example: required
+          nullable: true
+        message:
+          type: string
+          example: Login Required
+          nullable: true
+        location_type:
+          type: string
+          example: header
+          enum:
+            - header
+            - body
+            - query
+            - parameter
+          nullable: true
+        location:
+          type: string
+          example: Authorization
+          nullable: true

--- a/apis/v1/zz_client_gen.go
+++ b/apis/v1/zz_client_gen.go
@@ -991,49 +991,49 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
-	// ListApplicationsWithResponse request
+	// ListApplications request
 	ListApplicationsWithResponse(ctx context.Context, params *ListApplicationsParams, reqEditors ...RequestEditorFn) (*ListApplicationsResponse, error)
 
-	// PostApplicationWithBodyWithResponse request with any body
+	// PostApplication request with any body
 	PostApplicationWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostApplicationResponse, error)
 
 	PostApplicationWithResponse(ctx context.Context, body PostApplicationJSONRequestBody, reqEditors ...RequestEditorFn) (*PostApplicationResponse, error)
 
-	// DeleteApplicationWithResponse request
+	// DeleteApplication request
 	DeleteApplicationWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteApplicationResponse, error)
 
-	// GetApplicationWithResponse request
+	// GetApplication request
 	GetApplicationWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetApplicationResponse, error)
 
-	// PatchApplicationWithBodyWithResponse request with any body
+	// PatchApplication request with any body
 	PatchApplicationWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchApplicationResponse, error)
 
 	PatchApplicationWithResponse(ctx context.Context, id string, body PatchApplicationJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchApplicationResponse, error)
 
-	// GetApplicationStatusWithResponse request
+	// GetApplicationStatus request
 	GetApplicationStatusWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetApplicationStatusResponse, error)
 
-	// ListApplicationTrafficsWithResponse request
+	// ListApplicationTraffics request
 	ListApplicationTrafficsWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ListApplicationTrafficsResponse, error)
 
-	// PutApplicationTrafficWithBodyWithResponse request with any body
+	// PutApplicationTraffic request with any body
 	PutApplicationTrafficWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutApplicationTrafficResponse, error)
 
 	PutApplicationTrafficWithResponse(ctx context.Context, id string, body PutApplicationTrafficJSONRequestBody, reqEditors ...RequestEditorFn) (*PutApplicationTrafficResponse, error)
 
-	// ListApplicationVersionsWithResponse request
+	// ListApplicationVersions request
 	ListApplicationVersionsWithResponse(ctx context.Context, id string, params *ListApplicationVersionsParams, reqEditors ...RequestEditorFn) (*ListApplicationVersionsResponse, error)
 
-	// DeleteApplicationVersionWithResponse request
+	// DeleteApplicationVersion request
 	DeleteApplicationVersionWithResponse(ctx context.Context, id string, versionId string, reqEditors ...RequestEditorFn) (*DeleteApplicationVersionResponse, error)
 
-	// GetApplicationVersionWithResponse request
+	// GetApplicationVersion request
 	GetApplicationVersionWithResponse(ctx context.Context, id string, versionId string, reqEditors ...RequestEditorFn) (*GetApplicationVersionResponse, error)
 
-	// GetUserWithResponse request
+	// GetUser request
 	GetUserWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetUserResponse, error)
 
-	// PostUserWithResponse request
+	// PostUser request
 	PostUserWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PostUserResponse, error)
 }
 
@@ -1063,6 +1063,19 @@ func (r ListApplicationsResponse) StatusCode() int {
 	return 0
 }
 
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r ListApplicationsResponse) Result() (*HandlerListApplications, error) {
+	return r.JSON200, eCoalesce(r.JSON400, r.JSON401, r.JSON403, r.JSON500, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r ListApplicationsResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
+
 type PostApplicationResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -1088,6 +1101,19 @@ func (r PostApplicationResponse) StatusCode() int {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
+}
+
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r PostApplicationResponse) Result() (*HandlerPostApplication, error) {
+	return r.JSON201, eCoalesce(r.JSON400, r.JSON401, r.JSON403, r.JSON409, r.JSON500, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r PostApplicationResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
 }
 
 type DeleteApplicationResponse struct {
@@ -1116,6 +1142,19 @@ func (r DeleteApplicationResponse) StatusCode() int {
 	return 0
 }
 
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r DeleteApplicationResponse) Result() error {
+	return eCoalesce(r.JSON400, r.JSON401, r.JSON403, r.JSON404, r.JSON500, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r DeleteApplicationResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
+
 type GetApplicationResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -1141,6 +1180,19 @@ func (r GetApplicationResponse) StatusCode() int {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
+}
+
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r GetApplicationResponse) Result() (*HandlerGetApplication, error) {
+	return r.JSON200, eCoalesce(r.JSON400, r.JSON401, r.JSON403, r.JSON404, r.JSON500, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r GetApplicationResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
 }
 
 type PatchApplicationResponse struct {
@@ -1171,6 +1223,19 @@ func (r PatchApplicationResponse) StatusCode() int {
 	return 0
 }
 
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r PatchApplicationResponse) Result() (*HandlerPatchApplication, error) {
+	return r.JSON200, eCoalesce(r.JSON400, r.JSON401, r.JSON403, r.JSON404, r.JSON409, r.JSON500, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r PatchApplicationResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
+
 type GetApplicationStatusResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -1196,6 +1261,19 @@ func (r GetApplicationStatusResponse) StatusCode() int {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
+}
+
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r GetApplicationStatusResponse) Result() (*HandlerGetApplicationStatusResponse, error) {
+	return r.JSON200, eCoalesce(r.JSON400, r.JSON401, r.JSON403, r.JSON404, r.JSON500, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r GetApplicationStatusResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
 }
 
 type ListApplicationTrafficsResponse struct {
@@ -1225,6 +1303,19 @@ func (r ListApplicationTrafficsResponse) StatusCode() int {
 	return 0
 }
 
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r ListApplicationTrafficsResponse) Result() (*HandlerListTraffics, error) {
+	return r.JSON200, eCoalesce(r.JSON400, r.JSON401, r.JSON403, r.JSON404, r.JSON500, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r ListApplicationTrafficsResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
+
 type PutApplicationTrafficResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -1250,6 +1341,19 @@ func (r PutApplicationTrafficResponse) StatusCode() int {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
+}
+
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r PutApplicationTrafficResponse) Result() (*HandlerPutTraffics, error) {
+	return r.JSON200, eCoalesce(r.JSON400, r.JSON401, r.JSON403, r.JSON404, r.JSON500, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r PutApplicationTrafficResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
 }
 
 type ListApplicationVersionsResponse struct {
@@ -1279,6 +1383,19 @@ func (r ListApplicationVersionsResponse) StatusCode() int {
 	return 0
 }
 
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r ListApplicationVersionsResponse) Result() (*HandlerListVersions, error) {
+	return r.JSON200, eCoalesce(r.JSON400, r.JSON401, r.JSON403, r.JSON404, r.JSON500, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r ListApplicationVersionsResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
+
 type DeleteApplicationVersionResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -1303,6 +1420,19 @@ func (r DeleteApplicationVersionResponse) StatusCode() int {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
+}
+
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r DeleteApplicationVersionResponse) Result() error {
+	return eCoalesce(r.JSON400, r.JSON401, r.JSON403, r.JSON404, r.JSON500, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r DeleteApplicationVersionResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
 }
 
 type GetApplicationVersionResponse struct {
@@ -1332,6 +1462,19 @@ func (r GetApplicationVersionResponse) StatusCode() int {
 	return 0
 }
 
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r GetApplicationVersionResponse) Result() (*HandlerGetVersion, error) {
+	return r.JSON200, eCoalesce(r.JSON400, r.JSON401, r.JSON403, r.JSON404, r.JSON500, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r GetApplicationVersionResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
+
 type GetUserResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -1357,6 +1500,19 @@ func (r GetUserResponse) StatusCode() int {
 	return 0
 }
 
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r GetUserResponse) Result() error {
+	return eCoalesce(r.JSON401, r.JSON403, r.JSON404, r.JSON500, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r GetUserResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
+}
+
 type PostUserResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -1380,6 +1536,19 @@ func (r PostUserResponse) StatusCode() int {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
+}
+
+// Result JSON200の結果、もしくは発生したエラーのいずれかを返す
+func (r PostUserResponse) Result() error {
+	return eCoalesce(r.JSON401, r.JSON403, r.JSON409, r.JSON500, r.UndefinedError())
+}
+
+// UndefinedError API定義で未定義なエラーステータスコードを受け取った場合にエラーを返す
+func (r PostUserResponse) UndefinedError() error {
+	if !isOKStatus(r.HTTPResponse.StatusCode) {
+		return fmt.Errorf("unknown error: code:%d, body:%s", r.HTTPResponse.StatusCode, string(r.Body))
+	}
+	return nil
 }
 
 // ListApplicationsWithResponse request returning *ListApplicationsResponse

--- a/apis/v1/zz_types_gen.go
+++ b/apis/v1/zz_types_gen.go
@@ -75,12 +75,12 @@ const (
 	HandlerPatchApplicationStatusUnknown HandlerPatchApplicationStatus = "Unknown"
 )
 
-// Defines values for ModelErrorsLocationType.
+// Defines values for ModelErrorLocationType.
 const (
-	ModelErrorsLocationTypeBody      ModelErrorsLocationType = "body"
-	ModelErrorsLocationTypeHeader    ModelErrorsLocationType = "header"
-	ModelErrorsLocationTypeParameter ModelErrorsLocationType = "parameter"
-	ModelErrorsLocationTypeQuery     ModelErrorsLocationType = "query"
+	ModelErrorLocationTypeBody      ModelErrorLocationType = "body"
+	ModelErrorLocationTypeHeader    ModelErrorLocationType = "header"
+	ModelErrorLocationTypeParameter ModelErrorLocationType = "parameter"
+	ModelErrorLocationTypeQuery     ModelErrorLocationType = "query"
 )
 
 // Defines values for PatchApplicationBodyComponentMaxCpu.
@@ -427,24 +427,27 @@ type HandlerPutTraffics struct {
 
 // ModelDefaultError defines model for model.defaultError.
 type ModelDefaultError struct {
-	Error *struct {
+	Detail *struct {
 		Code    *float32     `json:"code,omitempty"`
 		Errors  *ModelErrors `json:"errors,omitempty"`
 		Message *string      `json:"message,omitempty"`
 	} `json:"error,omitempty"`
 }
 
-// ModelErrors defines model for model.errors.
-type ModelErrors = []struct {
-	Domain       *string                  `json:"domain"`
-	Location     *string                  `json:"location"`
-	LocationType *ModelErrorsLocationType `json:"location_type"`
-	Message      *string                  `json:"message"`
-	Reason       *string                  `json:"reason"`
+// ModelError defines model for model.error.
+type ModelError struct {
+	Domain       *string                 `json:"domain"`
+	Location     *string                 `json:"location"`
+	LocationType *ModelErrorLocationType `json:"location_type"`
+	Message      *string                 `json:"message"`
+	Reason       *string                 `json:"reason"`
 }
 
-// ModelErrorsLocationType defines model for ModelErrors.LocationType.
-type ModelErrorsLocationType string
+// ModelErrorLocationType defines model for ModelError.LocationType.
+type ModelErrorLocationType string
+
+// ModelErrors defines model for model.errors.
+type ModelErrors = []ModelError
 
 // PatchApplicationBody defines model for patchApplicationBody.
 type PatchApplicationBody struct {


### PR DESCRIPTION
- openapi.yamlの修正
  - model.errorsからArrayの中身をobjectとして切り出し
  - model.defaultErrorで生成されるstructでerror interfaceを実装できるように調整
- コードテンプレートを修正し各レスポンス型でResult()を使えるように
- レスポンス型でのResults()で必要なfunc類の実装

基本的には https://github.com/sacloud/object-storage-api-go/pull/10 を踏襲し、object-storage-api-go とできるだけ同じ仕様になることを目指しています。