### PR TITLE
.goreleaser.yml を追加

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,24 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    main: ./cmd/sacloud-apprun-fake-server
+    ldflags:
+      - -s -w
+      - -X github.com/sacloud/apprun-api-go/version.Revision={{.ShortCommit}}
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    binary: "sacloud-apprun-fake-server"
+
+changelog:
+  disable: false


### PR DESCRIPTION
## 背景
.goreleaser.yml が存在しなかったので作成しました。

## 変更点
- `goreleaser init` でデフォルトの `.goreleaser.yaml` を作成
- https://github.com/sacloud/object-storage-api-go/blob/main/.goreleaser.yml を参考にしつつ修正


