### PR TITLE
ApplicationのComponents.DataSourceからDeploySourceへの変更の対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ func main() {
 				Name:      "component1",
 				MaxCpu:    "0.1",
 				MaxMemory: "256Mi",
-				Datasource: v1.PostApplicationBodyComponentDataSource{
-					ContainerRegistry: &v1.PostApplicationBodyComponentDataSourceContainerRegistry{
+				DeploySource: v1.PostApplicationBodyComponentDeploySource{
+					ContainerRegistry: &v1.PostApplicationBodyComponentDeploySourceContainerRegistry{
 						Image: "apprun-test.sakuracr.jp/apprun/test1:latest",
 					},
 				},

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -72,8 +72,8 @@ func TestApplicationAPI(t *testing.T) {
 				Name:      "component1",
 				MaxCpu:    "0.1",
 				MaxMemory: "256Mi",
-				Datasource: v1.PostApplicationBodyComponentDataSource{
-					ContainerRegistry: &v1.PostApplicationBodyComponentDataSourceContainerRegistry{
+				DeploySource: v1.PostApplicationBodyComponentDeploySource{
+					ContainerRegistry: &v1.PostApplicationBodyComponentDeploySourceContainerRegistry{
 						Image: "apprun-test.sakuracr.jp/apprun/test1:latest",
 					},
 				},
@@ -144,8 +144,9 @@ func TestVersionAPI(t *testing.T) {
 				Name:      "component1",
 				MaxCpu:    "0.1",
 				MaxMemory: "256Mi",
-				Datasource: v1.PostApplicationBodyComponentDataSource{
-					ContainerRegistry: &v1.PostApplicationBodyComponentDataSourceContainerRegistry{
+
+				DeploySource: v1.PostApplicationBodyComponentDeploySource{
+					ContainerRegistry: &v1.PostApplicationBodyComponentDeploySourceContainerRegistry{
 						Image: "apprun-test.sakuracr.jp/apprun/test1:latest",
 					},
 				},
@@ -212,8 +213,8 @@ func TestTrafficAPI(t *testing.T) {
 				Name:      "component1",
 				MaxCpu:    "0.1",
 				MaxMemory: "256Mi",
-				Datasource: v1.PostApplicationBodyComponentDataSource{
-					ContainerRegistry: &v1.PostApplicationBodyComponentDataSourceContainerRegistry{
+				DeploySource: v1.PostApplicationBodyComponentDeploySource{
+					ContainerRegistry: &v1.PostApplicationBodyComponentDeploySourceContainerRegistry{
 						Image: "apprun-test.sakuracr.jp/apprun/test1:latest",
 					},
 				},

--- a/apis/v1/spec/openapi.yaml
+++ b/apis/v1/spec/openapi.yaml
@@ -138,7 +138,7 @@ info:
           "name": "Component01",
           "max_cpu": "0.1",
           "max_memory": "256Mi",
-          "datasource": {
+          "deploy_source": {
             "container_registry": {
               "image": "my-app.sakuracr.jp/my-app:latest"
             }
@@ -191,7 +191,7 @@ info:
           "name": "Component01 updated",
           "max_cpu": "0.1",
           "max_memory": "256Mi",
-          "datasource": {
+          "deploy_source": {
             "container_registry": {
               "image": "my-app.sakuracr.jp/my-app-v2:latest"
             }
@@ -300,7 +300,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/model.defaultError"
         "404":
-          description: さくらのAppRunにユーザーが存在しません
+          description: さくらのAppRunにユーザーが存在しません。
           content:
             application/json:
               schema:
@@ -1314,7 +1314,7 @@ components:
         - name
         - max_cpu
         - max_memory
-        - datasource
+        - deploy_source
       properties:
         name:
           description: コンポーネント名
@@ -1346,9 +1346,9 @@ components:
             - 512Mi
             - 1Gi
             - 2Gi
-        datasource:
+        deploy_source:
           description: コンポーネントを構成するソース
-          $ref: "#/components/schemas/postApplicationBodyComponentDataSource"
+          $ref: "#/components/schemas/postApplicationBodyComponentDeploySource"
         env:
           description: コンポーネントに渡す環境変数
           type: array
@@ -1358,13 +1358,13 @@ components:
         probe:
           description: コンポーネントのプローブ設定
           $ref: "#/components/schemas/postApplicationBodyComponentProbe"
-    postApplicationBodyComponentDataSource:
+    postApplicationBodyComponentDeploySource:
       type: object
       properties:
         container_registry:
           description: コンテナレジストリ
-          $ref: "#/components/schemas/postApplicationBodyComponentDataSourceContainerRegistry"
-    postApplicationBodyComponentDataSourceContainerRegistry:
+          $ref: "#/components/schemas/postApplicationBodyComponentDeploySourceContainerRegistry"
+    postApplicationBodyComponentDeploySourceContainerRegistry:
       type: object
       required:
         - image
@@ -1494,7 +1494,7 @@ components:
         - name
         - max_cpu
         - max_memory
-        - datasource
+        - deploy_source
       properties:
         name:
           description: コンポーネント名
@@ -1526,22 +1526,22 @@ components:
             - 512Mi
             - 1Gi
             - 2Gi
-        datasource:
+        deploy_source:
           description: コンポーネントを構成するソース
-          $ref: "#/components/schemas/patchApplicationBodyComponentDataSource"
+          $ref: "#/components/schemas/patchApplicationBodyComponentDeploySource"
         env:
           description: コンポーネントに渡す環境変数
           $ref: "#/components/schemas/patchApplicationBodyComponentEnv"
         probe:
           description: コンポーネントのプローブ設定
           $ref: "#/components/schemas/patchApplicationBodyComponentProbe"
-    patchApplicationBodyComponentDataSource:
+    patchApplicationBodyComponentDeploySource:
       type: object
       properties:
         container_registry:
           description: コンテナレジストリ
-          $ref: "#/components/schemas/patchApplicationBodyComponentDataSourceContainerRegistry"
-    patchApplicationBodyComponentDataSourceContainerRegistry:
+          $ref: "#/components/schemas/patchApplicationBodyComponentDeploySourceContainerRegistry"
+    patchApplicationBodyComponentDeploySourceContainerRegistry:
       type: object
       required:
         - image
@@ -1692,7 +1692,7 @@ components:
         - name
         - max_cpu
         - max_memory
-        - datasource
+        - deploy_source
       properties:
         name:
           description: コンポーネント名
@@ -1706,9 +1706,9 @@ components:
           description: コンポーネントの最大メモリ
           type: string
           example: 256Mi
-        datasource:
+        deploy_source:
           description: コンポーネントを構成するソース
-          $ref: "#/components/schemas/handler.ApplicationComponentDataSource"
+          $ref: "#/components/schemas/handler.ApplicationComponentDeploySource"
         env:
           description: コンポーネントに渡す環境変数
           type: array
@@ -1717,13 +1717,13 @@ components:
         probe:
           description: コンポーネントのプローブ設定
           $ref: "#/components/schemas/handler.ApplicationComponentProbe"
-    handler.ApplicationComponentDataSource:
+    handler.ApplicationComponentDeploySource:
       type: object
       properties:
         container_registry:
           description: コンテナレジストリ
-          $ref: "#/components/schemas/handler.ApplicationComponentDataSourceContainerRegistry"
-    handler.ApplicationComponentDataSourceContainerRegistry:
+          $ref: "#/components/schemas/handler.ApplicationComponentDeploySourceContainerRegistry"
+    handler.ApplicationComponentDeploySourceContainerRegistry:
       type: object
       required:
         - image

--- a/apis/v1/spec/original-openapi.json
+++ b/apis/v1/spec/original-openapi.json
@@ -9,7 +9,7 @@
     "license": {
       "name": "Copyright(C) SAKURA internet Inc. all rights reserved."
     },
-    "description": "---\n「さくらのAppRun」が提供するAPIの利用方法とサンプルを公開しております。\n\n# 基本的な使い方\n\n## APIキーの発行\n\nAPIを利用するためには、認証のための「APIキー」が必要です。事前にキーを発行しておきます。  \nAPIキーは「ユーザーID」「パスワード」に相当する「トークン」と呼ばれる認証情報で構成されています。\n\n|   項目名   | APIキー発行時の項目名        | このドキュメント内での例             |\n|------------|------------------------------|--------------------------------------|\n| ユーザーID | アクセストークン(UUID)       | 01234567-89ab-cdef-0123-456789abcdef |\n| パスワード | アクセストークンシークレット | SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM |\n\n<div class=\"warning\">\n<b>操作マニュアル</b><br />\n<ul><li><a href=\"https://manual.sakura.ad.jp/cloud/api/apikey.html\">APIキー | さくらのクラウド ドキュメント</a></li></ul>\n</div>\n\n## 入力パラメータ\n\nAPIの入力には送信先URLに対して、いくつかのヘッダーとAPIキーを送信します。\n\n* 認証方式はHTTP Basic認証です。APIキーのアクセストークンをユーザーID、アクセストークンシークレットをパスワードとして指定します。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     'https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications'\n```\n\n## 出力結果と応答コード（HTTPステータスコード）\n\nAPIからの結果は、「応答コード（HTTPステータスコード）」と、「JSON形式(UTF-8)の結果」として出力されます。\n\n応答コードは、リクエストが成功したのか、失敗したのか大まかな情報を判断することができるもので、例えば失敗したときには、なぜこのような結果になったのかなど、具体的な情報は応答コードと主に返された本文を見ることで把握することができます。\n\n| 結果                                | 応答コード/status   |\n|-------------------------------------|---------------------|\n| 成功（要求を受け付けた）            | 2xx                 |\n| 失敗（要求が受け付けられなかった）  | 4xx, 5xx            |\n\n```\n# 出力結果サンプル（レスポンスヘッダー）\nHTTP/1.1 200 OK\nServer: nginx\nDate: Tue, 16 Nov 2021 12:39:48 GMT\nContent-Type: application/json; charset=UTF-8\nContent-Length: 443\nConnection: keep-alive\nStatus: 200 OK\nPragma: no-cache\nCache-Control: no-cache\nX-Sakura-Proxy-Microtime: 66245\nX-Sakura-Proxy-Decode-Microtime: 62\nX-Sakura-Content-Length: 443\nX-Sakura-Serial: 86ab6c743f72aa5ea6f17e254fd5f803\nX-Content-Type-Options: nosniff\nX-XSS-Protection: 1; mode=block\nX-Frame-Options: DENY\nX-Sakura-Encode-Microtime: 260\nVary: Accept-Encoding\n```\n\n```\n# 出力結果サンプル（レスポンスボディー）\n{\n  \"error\": {\n    \"code\": 401,\n    \"message\": \"Login Required\",\n    \"errors\": [\n      {\n        \"domain\": \"global\",\n        \"reason\": \"required\",\n        \"message\": \"Login Required\",\n        \"location_type\": \"header\",\n        \"location\": \"Authorization\"\n      }\n    ]\n  }\n}\n```\n\n# 利用例\n\n## 1.ユーザーの作成\n\nAppRunの利用を開始するには**ユーザー**を作成します。\n\nユーザーとは、AppRunを利用するための独立したユーザーであり、ユーザー作成および削除による料金の発生はございません。  \nなお、すでにユーザーを作成済みの場合は、再度ユーザーの作成は不要です。\n\nユーザーを作成するには以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X POST \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/user\n```\n\nユーザーの作成が完了すると、\n\n* アプリケーションの作成、更新、削除\n* バージョンの確認、削除\n* トラフィック分散の確認、変更\n\nなどの操作が可能になります。\n\n## 2.アプリケーションの作成、取得、更新、削除\n\nユーザーを作成後、**アプリケーション**の作成、更新、削除が可能になります。\n\nアプリケーションを作成するには以下のような入力を行います。\n\n```\n# 入力サンプル\nvi request_body.json\ncat request_body.json\n{\n  \"name\": \"Application\",\n  \"timeout_seconds\": 60,\n  \"port\": 8080,\n  \"min_scale\": 0,\n  \"max_scale\": 1,\n  \"components\": [\n    {\n      \"name\": \"Component01\",\n      \"max_cpu\": \"0.1\",\n      \"max_memory\": \"256Mi\",\n      \"datasource\": {\n        \"container_registry\": {\n          \"image\": \"my-app.sakuracr.jp/my-app:latest\"\n        }\n      },\n      \"env\": [\n        {\n          \"key\": \"TARGET\",\n          \"value\": \"World\"\n        }\n      ],\n      \"probe\": {\n        \"http_get\": {\n          \"path\": \"/\",\n          \"port\": 8080,\n          \"headers\": [\n            {\n              \"name\": \"Custom-Header\",\n              \"value\": \"Awesome\"\n            }\n          ]\n        }\n      }\n    }\n  ]\n}\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X POST \\\n     -d '@request_body.json' \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications\n```\n\n上記で作成したアプリケーションを取得するには以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X GET \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/{id}\n```\n\n上記で作成したアプリケーションを更新するには以下のような入力を行います。\n\n```\n# 入力サンプル\nvi request_body.json\ncat request_body.json\n{\n  \"components\": [\n    {\n      \"name\": \"Component01 updated\",\n      \"max_cpu\": \"0.1\",\n      \"max_memory\": \"256Mi\",\n      \"datasource\": {\n        \"container_registry\": {\n          \"image\": \"my-app.sakuracr.jp/my-app-v2:latest\"\n        }\n      }\n    }\n  ],\n  \"all_traffic_available\": true\n}\n\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X PATCH \\\n     -d '@request_body.json' \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/{id}\n```\n\n上記で作成したアプリケーションを削除するには以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X DELETE \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/{id}\n```\n\n## 3.バージョンの取得、削除\n\nアプリケーションを作成、更新した際、その設定情報をバージョンとして保存します。\n\nバージョンを取得するには以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X GET \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/{id}/versions/{version_id}\n```\n\n上記で作成したバージョンを削除するには以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X DELETE \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/{id}/versions/{version_id}\n```\n\n## 4.トラフィック分散の確認、変更\n\nアプリケーションは指定のバージョンへトラフィックを分散します。\n\nトラフィック分散を確認するには以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X GET \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/{id}/traffics\n```\n\nトラフィック分散を変更するには以下のような入力を行います。\n\n```\n# 入力サンプル\nvi request_body.json\ncat request_body.json\n[\n  {\n    \"is_latest_version\": true,\n    \"percent\": 50\n  },\n  {\n    \"version_name\": \"Application-861850d6-8240-7c31-9b69-80ea4466918d-1726726814\",\n    \"percent\": 50\n  }\n]\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X PUT \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/{id}/traffics\n```\n----"
+    "description": "---\n「さくらのAppRun」が提供するAPIの利用方法とサンプルを公開しております。\n\n# 基本的な使い方\n\n## APIキーの発行\n\nAPIを利用するためには、認証のための「APIキー」が必要です。事前にキーを発行しておきます。  \nAPIキーは「ユーザーID」「パスワード」に相当する「トークン」と呼ばれる認証情報で構成されています。\n\n|   項目名   | APIキー発行時の項目名        | このドキュメント内での例             |\n|------------|------------------------------|--------------------------------------|\n| ユーザーID | アクセストークン(UUID)       | 01234567-89ab-cdef-0123-456789abcdef |\n| パスワード | アクセストークンシークレット | SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM |\n\n<div class=\"warning\">\n<b>操作マニュアル</b><br />\n<ul><li><a href=\"https://manual.sakura.ad.jp/cloud/api/apikey.html\">APIキー | さくらのクラウド ドキュメント</a></li></ul>\n</div>\n\n## 入力パラメータ\n\nAPIの入力には送信先URLに対して、いくつかのヘッダーとAPIキーを送信します。\n\n* 認証方式はHTTP Basic認証です。APIキーのアクセストークンをユーザーID、アクセストークンシークレットをパスワードとして指定します。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     'https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications'\n```\n\n## 出力結果と応答コード（HTTPステータスコード）\n\nAPIからの結果は、「応答コード（HTTPステータスコード）」と、「JSON形式(UTF-8)の結果」として出力されます。\n\n応答コードは、リクエストが成功したのか、失敗したのか大まかな情報を判断することができるもので、例えば失敗したときには、なぜこのような結果になったのかなど、具体的な情報は応答コードと主に返された本文を見ることで把握することができます。\n\n| 結果                                | 応答コード/status   |\n|-------------------------------------|---------------------|\n| 成功（要求を受け付けた）            | 2xx                 |\n| 失敗（要求が受け付けられなかった）  | 4xx, 5xx            |\n\n```\n# 出力結果サンプル（レスポンスヘッダー）\nHTTP/1.1 200 OK\nServer: nginx\nDate: Tue, 16 Nov 2021 12:39:48 GMT\nContent-Type: application/json; charset=UTF-8\nContent-Length: 443\nConnection: keep-alive\nStatus: 200 OK\nPragma: no-cache\nCache-Control: no-cache\nX-Sakura-Proxy-Microtime: 66245\nX-Sakura-Proxy-Decode-Microtime: 62\nX-Sakura-Content-Length: 443\nX-Sakura-Serial: 86ab6c743f72aa5ea6f17e254fd5f803\nX-Content-Type-Options: nosniff\nX-XSS-Protection: 1; mode=block\nX-Frame-Options: DENY\nX-Sakura-Encode-Microtime: 260\nVary: Accept-Encoding\n```\n\n```\n# 出力結果サンプル（レスポンスボディー）\n{\n  \"error\": {\n    \"code\": 401,\n    \"message\": \"Login Required\",\n    \"errors\": [\n      {\n        \"domain\": \"global\",\n        \"reason\": \"required\",\n        \"message\": \"Login Required\",\n        \"location_type\": \"header\",\n        \"location\": \"Authorization\"\n      }\n    ]\n  }\n}\n```\n\n# 利用例\n\n## 1.ユーザーの作成\n\nAppRunの利用を開始するには**ユーザー**を作成します。\n\nユーザーとは、AppRunを利用するための独立したユーザーであり、ユーザー作成および削除による料金の発生はございません。  \nなお、すでにユーザーを作成済みの場合は、再度ユーザーの作成は不要です。\n\nユーザーを作成するには以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X POST \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/user\n```\n\nユーザーの作成が完了すると、\n\n* アプリケーションの作成、更新、削除\n* バージョンの確認、削除\n* トラフィック分散の確認、変更\n\nなどの操作が可能になります。\n\n## 2.アプリケーションの作成、取得、更新、削除\n\nユーザーを作成後、**アプリケーション**の作成、更新、削除が可能になります。\n\nアプリケーションを作成するには以下のような入力を行います。\n\n```\n# 入力サンプル\nvi request_body.json\ncat request_body.json\n{\n  \"name\": \"Application\",\n  \"timeout_seconds\": 60,\n  \"port\": 8080,\n  \"min_scale\": 0,\n  \"max_scale\": 1,\n  \"components\": [\n    {\n      \"name\": \"Component01\",\n      \"max_cpu\": \"0.1\",\n      \"max_memory\": \"256Mi\",\n      \"deploy_source\": {\n        \"container_registry\": {\n          \"image\": \"my-app.sakuracr.jp/my-app:latest\"\n        }\n      },\n      \"env\": [\n        {\n          \"key\": \"TARGET\",\n          \"value\": \"World\"\n        }\n      ],\n      \"probe\": {\n        \"http_get\": {\n          \"path\": \"/\",\n          \"port\": 8080,\n          \"headers\": [\n            {\n              \"name\": \"Custom-Header\",\n              \"value\": \"Awesome\"\n            }\n          ]\n        }\n      }\n    }\n  ]\n}\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X POST \\\n     -d '@request_body.json' \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications\n```\n\n上記で作成したアプリケーションを取得するには以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X GET \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/{id}\n```\n\n上記で作成したアプリケーションを更新するには以下のような入力を行います。\n\n```\n# 入力サンプル\nvi request_body.json\ncat request_body.json\n{\n  \"components\": [\n    {\n      \"name\": \"Component01 updated\",\n      \"max_cpu\": \"0.1\",\n      \"max_memory\": \"256Mi\",\n      \"deploy_source\": {\n        \"container_registry\": {\n          \"image\": \"my-app.sakuracr.jp/my-app-v2:latest\"\n        }\n      }\n    }\n  ],\n  \"all_traffic_available\": true\n}\n\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X PATCH \\\n     -d '@request_body.json' \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/{id}\n```\n\n上記で作成したアプリケーションを削除するには以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X DELETE \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/{id}\n```\n\n## 3.バージョンの取得、削除\n\nアプリケーションを作成、更新した際、その設定情報をバージョンとして保存します。\n\nバージョンを取得するには以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X GET \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/{id}/versions/{version_id}\n```\n\n上記で作成したバージョンを削除するには以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X DELETE \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/{id}/versions/{version_id}\n```\n\n## 4.トラフィック分散の確認、変更\n\nアプリケーションは指定のバージョンへトラフィックを分散します。\n\nトラフィック分散を確認するには以下のような入力を行います。\n\n```\n# 入力サンプル\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X GET \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/{id}/traffics\n```\n\nトラフィック分散を変更するには以下のような入力を行います。\n\n```\n# 入力サンプル\nvi request_body.json\ncat request_body.json\n[\n  {\n    \"is_latest_version\": true,\n    \"percent\": 50\n  },\n  {\n    \"version_name\": \"Application-861850d6-8240-7c31-9b69-80ea4466918d-1726726814\",\n    \"percent\": 50\n  }\n]\ncurl -u '01234567-89ab-cdef-0123-456789abcdef:SAMPLETOKENSAMPLETOKENSAMPLETOKENSAM' \\\n     -X PUT \\\n     https://secure.sakura.ad.jp/cloud/api/apprun/1.0/apprun/api/applications/{id}/traffics\n```\n----"
   },
   "servers": [
     {
@@ -49,7 +49,7 @@
             }
           },
           "404": {
-            "description": "さくらのAppRunにユーザーが存在しません",
+            "description": "さくらのAppRunにユーザーが存在しません。",
             "content": {
               "application/json": {
                 "schema": {
@@ -1262,7 +1262,7 @@
                 "name",
                 "max_cpu",
                 "max_memory",
-                "datasource"
+                "deploy_source"
               ],
               "properties": {
                 "name": {
@@ -1280,7 +1280,7 @@
                   "type": "string",
                   "example": "256Mi"
                 },
-                "datasource": {
+                "deploy_source": {
                   "description": "コンポーネントを構成するソース",
                   "type": "object",
                   "properties": {
@@ -1455,7 +1455,7 @@
                 "name",
                 "max_cpu",
                 "max_memory",
-                "datasource"
+                "deploy_source"
               ],
               "properties": {
                 "name": {
@@ -1473,7 +1473,7 @@
                   "type": "string",
                   "example": "256Mi"
                 },
-                "datasource": {
+                "deploy_source": {
                   "description": "コンポーネントを構成するソース",
                   "type": "object",
                   "properties": {
@@ -1645,7 +1645,7 @@
                 "name",
                 "max_cpu",
                 "max_memory",
-                "datasource"
+                "deploy_source"
               ],
               "properties": {
                 "name": {
@@ -1663,7 +1663,7 @@
                   "type": "string",
                   "example": "256Mi"
                 },
-                "datasource": {
+                "deploy_source": {
                   "description": "コンポーネントを構成するソース",
                   "type": "object",
                   "properties": {
@@ -1935,7 +1935,7 @@
                 "name",
                 "max_cpu",
                 "max_memory",
-                "datasource"
+                "deploy_source"
               ],
               "properties": {
                 "name": {
@@ -1953,7 +1953,7 @@
                   "type": "string",
                   "example": "256Mi"
                 },
-                "datasource": {
+                "deploy_source": {
                   "description": "コンポーネントを構成するソース",
                   "type": "object",
                   "properties": {
@@ -2182,7 +2182,7 @@
                 "name",
                 "max_cpu",
                 "max_memory",
-                "datasource"
+                "deploy_source"
               ],
               "properties": {
                 "name": {
@@ -2220,7 +2220,7 @@
                     "2Gi"
                   ]
                 },
-                "datasource": {
+                "deploy_source": {
                   "description": "コンポーネントを構成するソース",
                   "type": "object",
                   "properties": {
@@ -2386,7 +2386,7 @@
                 "name",
                 "max_cpu",
                 "max_memory",
-                "datasource"
+                "deploy_source"
               ],
               "properties": {
                 "name": {
@@ -2424,7 +2424,7 @@
                     "2Gi"
                   ]
                 },
-                "datasource": {
+                "deploy_source": {
                   "description": "コンポーネントを構成するソース",
                   "type": "object",
                   "properties": {

--- a/apis/v1/zz_types_gen.go
+++ b/apis/v1/zz_types_gen.go
@@ -207,7 +207,7 @@ type VersionStatus string
 
 // HandlerApplicationComponent defines model for handler.ApplicationComponent.
 type HandlerApplicationComponent struct {
-	Datasource HandlerApplicationComponentDataSource `json:"datasource"`
+	DeploySource HandlerApplicationComponentDeploySource `json:"deploy_source"`
 
 	// Env コンポーネントに渡す環境変数
 	Env *[]HandlerApplicationComponentEnv `json:"env,omitempty"`
@@ -223,13 +223,13 @@ type HandlerApplicationComponent struct {
 	Probe *HandlerApplicationComponentProbe `json:"probe"`
 }
 
-// HandlerApplicationComponentDataSource defines model for handler.ApplicationComponentDataSource.
-type HandlerApplicationComponentDataSource struct {
-	ContainerRegistry *HandlerApplicationComponentDataSourceContainerRegistry `json:"container_registry,omitempty"`
+// HandlerApplicationComponentDeploySource defines model for handler.ApplicationComponentDeploySource.
+type HandlerApplicationComponentDeploySource struct {
+	ContainerRegistry *HandlerApplicationComponentDeploySourceContainerRegistry `json:"container_registry,omitempty"`
 }
 
-// HandlerApplicationComponentDataSourceContainerRegistry defines model for handler.ApplicationComponentDataSourceContainerRegistry.
-type HandlerApplicationComponentDataSourceContainerRegistry struct {
+// HandlerApplicationComponentDeploySourceContainerRegistry defines model for handler.ApplicationComponentDeploySourceContainerRegistry.
+type HandlerApplicationComponentDeploySourceContainerRegistry struct {
 	// Image コンテナイメージ名
 	Image string `json:"image"`
 
@@ -480,8 +480,8 @@ type PatchApplicationBody struct {
 
 // PatchApplicationBodyComponent defines model for patchApplicationBodyComponent.
 type PatchApplicationBodyComponent struct {
-	Datasource PatchApplicationBodyComponentDataSource `json:"datasource"`
-	Env        *PatchApplicationBodyComponentEnv       `json:"env"`
+	DeploySource PatchApplicationBodyComponentDeploySource `json:"deploy_source"`
+	Env          *PatchApplicationBodyComponentEnv         `json:"env"`
 
 	// MaxCpu コンポーネントの最大CPU数
 	MaxCpu PatchApplicationBodyComponentMaxCpu `json:"max_cpu"`
@@ -500,13 +500,13 @@ type PatchApplicationBodyComponentMaxCpu string
 // PatchApplicationBodyComponentMaxMemory コンポーネントの最大メモリ
 type PatchApplicationBodyComponentMaxMemory string
 
-// PatchApplicationBodyComponentDataSource defines model for patchApplicationBodyComponentDataSource.
-type PatchApplicationBodyComponentDataSource struct {
-	ContainerRegistry *PatchApplicationBodyComponentDataSourceContainerRegistry `json:"container_registry,omitempty"`
+// PatchApplicationBodyComponentDeploySource defines model for patchApplicationBodyComponentDeploySource.
+type PatchApplicationBodyComponentDeploySource struct {
+	ContainerRegistry *PatchApplicationBodyComponentDeploySourceContainerRegistry `json:"container_registry,omitempty"`
 }
 
-// PatchApplicationBodyComponentDataSourceContainerRegistry defines model for patchApplicationBodyComponentDataSourceContainerRegistry.
-type PatchApplicationBodyComponentDataSourceContainerRegistry struct {
+// PatchApplicationBodyComponentDeploySourceContainerRegistry defines model for patchApplicationBodyComponentDeploySourceContainerRegistry.
+type PatchApplicationBodyComponentDeploySourceContainerRegistry struct {
 	// Image コンテナイメージ名
 	Image string `json:"image"`
 
@@ -572,7 +572,7 @@ type PostApplicationBody struct {
 
 // PostApplicationBodyComponent defines model for postApplicationBodyComponent.
 type PostApplicationBodyComponent struct {
-	Datasource PostApplicationBodyComponentDataSource `json:"datasource"`
+	DeploySource PostApplicationBodyComponentDeploySource `json:"deploy_source"`
 
 	// Env コンポーネントに渡す環境変数
 	Env *[]PostApplicationBodyComponentEnv `json:"env"`
@@ -594,13 +594,13 @@ type PostApplicationBodyComponentMaxCpu string
 // PostApplicationBodyComponentMaxMemory コンポーネントの最大メモリ
 type PostApplicationBodyComponentMaxMemory string
 
-// PostApplicationBodyComponentDataSource defines model for postApplicationBodyComponentDataSource.
-type PostApplicationBodyComponentDataSource struct {
-	ContainerRegistry *PostApplicationBodyComponentDataSourceContainerRegistry `json:"container_registry,omitempty"`
+// PostApplicationBodyComponentDeploySource defines model for postApplicationBodyComponentDeploySource.
+type PostApplicationBodyComponentDeploySource struct {
+	ContainerRegistry *PostApplicationBodyComponentDeploySourceContainerRegistry `json:"container_registry,omitempty"`
 }
 
-// PostApplicationBodyComponentDataSourceContainerRegistry defines model for postApplicationBodyComponentDataSourceContainerRegistry.
-type PostApplicationBodyComponentDataSourceContainerRegistry struct {
+// PostApplicationBodyComponentDeploySourceContainerRegistry defines model for postApplicationBodyComponentDeploySourceContainerRegistry.
+type PostApplicationBodyComponentDeploySourceContainerRegistry struct {
 	// Image コンテナイメージ名
 	Image string `json:"image"`
 

--- a/example_test.go
+++ b/example_test.go
@@ -65,8 +65,8 @@ func Example_applicationAPI() {
 				Name:      "component1",
 				MaxCpu:    "0.1",
 				MaxMemory: "256Mi",
-				Datasource: v1.PostApplicationBodyComponentDataSource{
-					ContainerRegistry: &v1.PostApplicationBodyComponentDataSourceContainerRegistry{
+				DeploySource: v1.PostApplicationBodyComponentDeploySource{
+					ContainerRegistry: &v1.PostApplicationBodyComponentDeploySourceContainerRegistry{
 						Image: "apprun-test.sakuracr.jp/apprun/test1:latest",
 					},
 				},
@@ -122,8 +122,8 @@ func Example_versionAPI() {
 				Name:      "component1",
 				MaxCpu:    "0.1",
 				MaxMemory: "256Mi",
-				Datasource: v1.PostApplicationBodyComponentDataSource{
-					ContainerRegistry: &v1.PostApplicationBodyComponentDataSourceContainerRegistry{
+				DeploySource: v1.PostApplicationBodyComponentDeploySource{
+					ContainerRegistry: &v1.PostApplicationBodyComponentDeploySourceContainerRegistry{
 						Image: "apprun-test.sakuracr.jp/apprun/test1:latest",
 					},
 				},
@@ -204,8 +204,8 @@ func Example_trafficAPI() {
 				Name:      "component1",
 				MaxCpu:    "0.1",
 				MaxMemory: "256Mi",
-				Datasource: v1.PostApplicationBodyComponentDataSource{
-					ContainerRegistry: &v1.PostApplicationBodyComponentDataSourceContainerRegistry{
+				DeploySource: v1.PostApplicationBodyComponentDeploySource{
+					ContainerRegistry: &v1.PostApplicationBodyComponentDeploySourceContainerRegistry{
 						Image: "apprun-test.sakuracr.jp/apprun/test1:latest",
 					},
 				},

--- a/fake/applications.go
+++ b/fake/applications.go
@@ -102,11 +102,11 @@ func (engine *Engine) CreateApplication(reqBody *v1.PostApplicationBody) (*v1.Ap
 
 	var components []v1.HandlerApplicationComponent
 	for _, reqComponent := range reqBody.Components {
-		var cr v1.HandlerApplicationComponentDataSourceContainerRegistry
-		if reqComponent.Datasource.ContainerRegistry != nil {
-			cr.Image = reqComponent.Datasource.ContainerRegistry.Image
-			cr.Server = reqComponent.Datasource.ContainerRegistry.Server
-			cr.Username = reqComponent.Datasource.ContainerRegistry.Username
+		var cr v1.HandlerApplicationComponentDeploySourceContainerRegistry
+		if reqComponent.DeploySource.ContainerRegistry != nil {
+			cr.Image = reqComponent.DeploySource.ContainerRegistry.Image
+			cr.Server = reqComponent.DeploySource.ContainerRegistry.Server
+			cr.Username = reqComponent.DeploySource.ContainerRegistry.Username
 		}
 
 		var env []v1.HandlerApplicationComponentEnv
@@ -138,7 +138,7 @@ func (engine *Engine) CreateApplication(reqBody *v1.PostApplicationBody) (*v1.Ap
 		component.Name = reqComponent.Name
 		component.MaxCpu = string(reqComponent.MaxCpu)
 		component.MaxMemory = string(reqComponent.MaxMemory)
-		component.Datasource.ContainerRegistry = &cr
+		component.DeploySource.ContainerRegistry = &cr
 		component.Env = &env
 		component.Probe = &probe
 		components = append(components, component)
@@ -214,11 +214,11 @@ func (engine *Engine) UpdateApplication(id string, reqBody *v1.PatchApplicationB
 	if reqBody.Components != nil && len(*reqBody.Components) > 0 {
 		var components []v1.HandlerApplicationComponent
 		for _, reqComponent := range *reqBody.Components {
-			var cr v1.HandlerApplicationComponentDataSourceContainerRegistry
-			if reqComponent.Datasource.ContainerRegistry != nil {
-				cr.Image = reqComponent.Datasource.ContainerRegistry.Image
-				cr.Server = reqComponent.Datasource.ContainerRegistry.Server
-				cr.Username = reqComponent.Datasource.ContainerRegistry.Username
+			var cr v1.HandlerApplicationComponentDeploySourceContainerRegistry
+			if reqComponent.DeploySource.ContainerRegistry != nil {
+				cr.Image = reqComponent.DeploySource.ContainerRegistry.Image
+				cr.Server = reqComponent.DeploySource.ContainerRegistry.Server
+				cr.Username = reqComponent.DeploySource.ContainerRegistry.Username
 			}
 
 			var env []v1.HandlerApplicationComponentEnv
@@ -250,7 +250,7 @@ func (engine *Engine) UpdateApplication(id string, reqBody *v1.PatchApplicationB
 			component.Name = reqComponent.Name
 			component.MaxCpu = string(reqComponent.MaxCpu)
 			component.MaxMemory = string(reqComponent.MaxMemory)
-			component.Datasource.ContainerRegistry = &cr
+			component.DeploySource.ContainerRegistry = &cr
 			component.Env = &env
 			component.Probe = &probe
 			components = append(components, component)

--- a/fake/applications_test.go
+++ b/fake/applications_test.go
@@ -102,7 +102,7 @@ func TestEngine_Application(t *testing.T) {
 					"name": "component1",
 					"max_cpu": "0.2",
 					"max_memory": "512Mi",
-					"datasource": {
+					"deploy_source": {
 						"container_registry": {
 							"image": "apprun-example.sakuracr.jp/helloworld:latest",
 							"server": "apprun-example.sakuracr.jp",
@@ -161,7 +161,7 @@ func TestEngine_Application(t *testing.T) {
 					"name": "component1",
 					"max_cpu": "0.2",
 					"max_memory": "512Mi",
-					"datasource": {
+					"deploy_source": {
 						"container_registry": {
 							"image": "apprun-example.sakuracr.jp/helloworld:latest",
 							"server": "apprun-example.sakuracr.jp",
@@ -253,8 +253,8 @@ func postApplicationBody() *v1.PostApplicationBody {
 				Name:      "component1",
 				MaxCpu:    "0.2",
 				MaxMemory: "512Mi",
-				Datasource: v1.PostApplicationBodyComponentDataSource{
-					ContainerRegistry: &v1.PostApplicationBodyComponentDataSourceContainerRegistry{
+				DeploySource: v1.PostApplicationBodyComponentDeploySource{
+					ContainerRegistry: &v1.PostApplicationBodyComponentDeploySourceContainerRegistry{
 						Image:    "apprun-example.sakuracr.jp/helloworld:latest",
 						Server:   &server,
 						Username: &userName,

--- a/fake/versions_test.go
+++ b/fake/versions_test.go
@@ -115,7 +115,7 @@ func TestEngine_Version(t *testing.T) {
 					"name": "component1",
 					"max_cpu": "0.2",
 					"max_memory": "512Mi",
-					"datasource": {
+					"deploy_source": {
 						"container_registry": {
 							"image": "apprun-example.sakuracr.jp/helloworld:latest",
 							"server": "apprun-example.sakuracr.jp",


### PR DESCRIPTION
## 背景
AppRunのApplication APIにおいて、Components.DataSourceがDeploySourceに命名変更されました。
https://manual.sakura.ad.jp/sakura-apprun-api/spec.html

この変更に追随する対応をします。

## 変更点
- openapi.yaml の作り直し
- DataSourceをDeploySourceに置換

## 動作確認
- [x] CIがパスする
- [x] 手元でacceptance_test.goを実行して、テストがパスする
