### PR TITLE
update to v0.1.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -16,7 +16,7 @@ package apprun
 
 var (
 	// Version app version
-	Version = "v0.0.1"
+	Version = "v0.1.0"
 	// Revision git commit short commit hash
 	Revision = "xxxxxx" // set on build time
 )


### PR DESCRIPTION
https://github.com/sacloud/apprun-api-go/pull/21 にてAPIスキーマの変更に対応しましたので、v0.1.0 へアップデートします。

ℹ️ [セマンティックバージョン](https://semver.org/lang/ja/) のプロトコルに従うと後方互換性のないアップデートはメジャーバージョンを上げるべきですが、現時点ではv1.0に達するまでは後方互換性のない形でアップデートすることにしておりますので、マイナーバージョンのアップデートとします。