### PR TITLE
OpenAPIのスキーマを修正

### DIFF
--- a/apis/v1/spec/openapi.yaml
+++ b/apis/v1/spec/openapi.yaml
@@ -1531,7 +1531,10 @@ components:
           $ref: "#/components/schemas/patchApplicationBodyComponentDeploySource"
         env:
           description: コンポーネントに渡す環境変数
-          $ref: "#/components/schemas/patchApplicationBodyComponentEnv"
+          type: array
+          nullable: true
+          items:
+            $ref: "#/components/schemas/patchApplicationBodyComponentEnv"
         probe:
           description: コンポーネントのプローブ設定
           $ref: "#/components/schemas/patchApplicationBodyComponentProbe"
@@ -1574,19 +1577,16 @@ components:
           maxLength: 63
           nullable: true
     patchApplicationBodyComponentEnv:
-      type: array
-      nullable: true
-      items:
-        type: object
-        properties:
-          key:
-            description: 環境変数名
-            type: string
-            example: MY_ENV
-          value:
-            description: 環境変数の値
-            type: string
-            example: my_value
+      type: object
+      properties:
+        key:
+          description: 環境変数名
+          type: string
+          example: MY_ENV
+        value:
+          description: 環境変数の値
+          type: string
+          example: my_value
     patchApplicationBodyComponentProbe:
       type: object
       nullable: true

--- a/apis/v1/spec/openapi.yaml
+++ b/apis/v1/spec/openapi.yaml
@@ -1593,35 +1593,39 @@ components:
       properties:
         http_get:
           description: HTTP Getプローブタイプ
-          type: object
-          required:
-            - path
-            - port
-          nullable: true
-          properties:
-            path:
-              description: HTTPサーバーへアクセスしプローブをチェックする際のパス
-              type: string
-              example: /healthz
-            port:
-              description: HTTPサーバーへアクセスしプローブをチェックする際のポート番号
-              type: integer
-              example: 8080
-              minimum: 1
-              maximum: 65535
-            headers:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    description: ヘッダーフィールド名
-                    type: string
-                    example: Custom-Header
-                  value:
-                    description: ヘッダーフィールド値
-                    type: string
-                    example: Awesome
+          $ref: "#/components/schemas/patchApplicationBodyComponentProbeHttpGet"
+    patchApplicationBodyComponentProbeHttpGet:
+      type: object
+      required:
+        - path
+        - port
+      nullable: true
+      properties:
+        path:
+          description: HTTPサーバーへアクセスしプローブをチェックする際のパス
+          type: string
+          example: /healthz
+        port:
+          description: HTTPサーバーへアクセスしプローブをチェックする際のポート番号
+          type: integer
+          example: 8080
+          minimum: 1
+          maximum: 65535
+        headers:
+          type: array
+          items:
+            $ref: "#/components/schemas/patchApplicationBodyComponentProbeHttpGetHeader"
+    patchApplicationBodyComponentProbeHttpGetHeader:
+      type: object
+      properties:
+        name:
+          description: ヘッダーフィールド名
+          type: string
+          example: Custom-Header
+        value:
+          description: ヘッダーフィールド値
+          type: string
+          example: Awesome
     putTrafficsBody:
       type: array
       items:

--- a/apis/v1/zz_types_gen.go
+++ b/apis/v1/zz_types_gen.go
@@ -481,7 +481,9 @@ type PatchApplicationBody struct {
 // PatchApplicationBodyComponent defines model for patchApplicationBodyComponent.
 type PatchApplicationBodyComponent struct {
 	DeploySource PatchApplicationBodyComponentDeploySource `json:"deploy_source"`
-	Env          *PatchApplicationBodyComponentEnv         `json:"env"`
+
+	// Env コンポーネントに渡す環境変数
+	Env *[]PatchApplicationBodyComponentEnv `json:"env"`
 
 	// MaxCpu コンポーネントの最大CPU数
 	MaxCpu PatchApplicationBodyComponentMaxCpu `json:"max_cpu"`
@@ -521,7 +523,7 @@ type PatchApplicationBodyComponentDeploySourceContainerRegistry struct {
 }
 
 // PatchApplicationBodyComponentEnv defines model for patchApplicationBodyComponentEnv.
-type PatchApplicationBodyComponentEnv = []struct {
+type PatchApplicationBodyComponentEnv struct {
 	// Key 環境変数名
 	Key *string `json:"key,omitempty"`
 

--- a/apis/v1/zz_types_gen.go
+++ b/apis/v1/zz_types_gen.go
@@ -533,22 +533,27 @@ type PatchApplicationBodyComponentEnv struct {
 
 // PatchApplicationBodyComponentProbe defines model for patchApplicationBodyComponentProbe.
 type PatchApplicationBodyComponentProbe struct {
-	// HttpGet HTTP Getプローブタイプ
-	HttpGet *struct {
-		Headers *[]struct {
-			// Name ヘッダーフィールド名
-			Name *string `json:"name,omitempty"`
+	HttpGet *PatchApplicationBodyComponentProbeHttpGet `json:"http_get"`
+}
 
-			// Value ヘッダーフィールド値
-			Value *string `json:"value,omitempty"`
-		} `json:"headers,omitempty"`
+// PatchApplicationBodyComponentProbeHttpGet defines model for patchApplicationBodyComponentProbeHttpGet.
+type PatchApplicationBodyComponentProbeHttpGet struct {
+	Headers *[]PatchApplicationBodyComponentProbeHttpGetHeader `json:"headers,omitempty"`
 
-		// Path HTTPサーバーへアクセスしプローブをチェックする際のパス
-		Path string `json:"path"`
+	// Path HTTPサーバーへアクセスしプローブをチェックする際のパス
+	Path string `json:"path"`
 
-		// Port HTTPサーバーへアクセスしプローブをチェックする際のポート番号
-		Port int `json:"port"`
-	} `json:"http_get"`
+	// Port HTTPサーバーへアクセスしプローブをチェックする際のポート番号
+	Port int `json:"port"`
+}
+
+// PatchApplicationBodyComponentProbeHttpGetHeader defines model for patchApplicationBodyComponentProbeHttpGetHeader.
+type PatchApplicationBodyComponentProbeHttpGetHeader struct {
+	// Name ヘッダーフィールド名
+	Name *string `json:"name,omitempty"`
+
+	// Value ヘッダーフィールド値
+	Value *string `json:"value,omitempty"`
 }
 
 // PostApplicationBody defines model for postApplicationBody.


### PR DESCRIPTION
## 背景
OpenAPIのスキーマの修正点漏れとミスがあったため修正を行います。

## 変更点
- [patchApplicationBodyComponentEnvをtype: objectに修正](https://github.com/sacloud/apprun-api-go/commit/1202662da26c3982d04299f4f07d6f6d66743915)
  - 間違えて `type: array` になってしまっていたので `type: object` にして、参照元に `type: array` を移動
- [PatchApplicationBodyComponentProbeを切り出し](https://github.com/sacloud/apprun-api-go/commit/cf075b27eaaaf754016e2399b927257367474ef5)
  - 配下のオブジェクトをPost同様に `patchApplicationBodyComponentProbeHttpGet`, `patchApplicationBodyComponentProbeHttpGetHeader` として切り出し

## 動作確認
- [x] CIが通ること
 