### PR TITLE
update v0.2.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -16,7 +16,7 @@ package apprun
 
 var (
 	// Version app version
-	Version = "v0.1.0"
+	Version = "v0.2.0"
 	// Revision git commit short commit hash
 	Revision = "xxxxxx" // set on build time
 )


### PR DESCRIPTION
https://github.com/sacloud/apprun-api-go/pull/25 にてOpenAPIのスキーマ変更をしましたので、v0.2.0へアップデートします。

ℹ️ [セマンティックバージョン](https://semver.org/lang/ja/) のプロトコルに従うと後方互換性のないアップデートはメジャーバージョンを上げるべきですが、現時点ではv1.0に達するまでは後方互換性のない形でアップデートすることにしておりますので、マイナーバージョンのアップデートとします。