### PR TITLE
lint openapi.yaml

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,17 @@ jobs:
           GOROOT=$(go env GOROOT)
           export GOROOT
           make lint-go
+  lint-def:
+    runs-on: ubuntu-latest
+    container:
+      image: stoplight/spectral:6
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
+      - name: lint
+        working-directory: .
+        run: spectral lint --ruleset .spectral.yaml apis/v1/spec/openapi.yaml
   test:
     name: test
     runs-on: ubuntu-latest

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,3 @@
+extends: 
+  - spectral:oas
+  - spectral:asyncapi

--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,5 @@ apis/v1/zz_server_gen.go: apis/v1/spec/openapi.yaml apis/v1/spec/codegen/gin.yam
 	oapi-codegen --old-config-style -config apis/v1/spec/codegen/gin.yaml apis/v1/spec/openapi.yaml
 
 lint-def:
-	docker run --rm -v $$PWD:$$PWD -w $$PWD stoplight/spectral:latest lint -F warn apis/v1/spec/openapi.yaml
+	# NOTE: 上流側のOpenAPI定義ではtag周りの警告が出るため "-F warn"の指定を外しておく
+	docker run --rm -v $$PWD:$$PWD -w $$PWD stoplight/spectral:latest lint apis/v1/spec/openapi.yaml


### PR DESCRIPTION
from #34

oepnapi.yamlに対し `spectral lint`を実施する。
`make lint-def`で手元で実行 + GitHub ActionsでCIとしての実行の2パターンで実行する。

Note: #36 をマージしないとlintが通らないため先に行う