### PR TITLE
 パケットフィルタAPIのスキーマを追加

### DIFF
--- a/apis/v1/spec/openapi.yaml
+++ b/apis/v1/spec/openapi.yaml
@@ -1303,6 +1303,60 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Traffic"
+    handler.getPacketFilter:
+      type: object
+      required:
+        - is_enabled
+        - settings
+      properties:
+        is_enabled:
+          type: boolean
+          description: 有効フラグ
+          example: true
+        settings:
+          type: array
+          maxItems: 5
+          items:
+            required:
+              - from_ip
+              - from_ip_prefix_length
+            properties:
+              from_ip:
+                type: string
+                description: 送信元IPv4アドレス
+                example: 0.0.0.0
+              from_ip_prefix_length:
+                type: integer
+                description: IPv4アドレスprefix長
+                minimum: 0
+                maximum: 32
+                example: 0
+    handler.patchPacketFilter:
+      type: object
+      required:
+        - is_enabled
+        - settings
+      properties:
+        is_enabled:
+          type: boolean
+          description: 有効フラグ
+          example: true
+        settings:
+          type: array
+          maxItems: 5
+          items:
+            required:
+              - from_ip
+              - from_ip_prefix_length
+            properties:
+              from_ip:
+                type: string
+                description: 送信元IPv4アドレス
+                example: 0.0.0.0
+              from_ip_prefix_length:
+                type: integer
+                description: IPv4アドレスprefix長
+                example: 0
     Traffic:
       type: object
       required:
@@ -1687,6 +1741,29 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/Traffic"
+    patchPacketFilter:
+      type: object
+      properties:
+        is_enabled:
+          type: boolean
+          description: 有効フラグ
+          example: true
+        settings:
+          type: array
+          maxItems: 5
+          items:
+            required:
+              - from_ip
+              - from_ip_prefix_length
+            properties:
+              from_ip:
+                type: string
+                description: 送信元IPv4アドレス
+                example: 0.0.0.0
+              from_ip_prefix_length:
+                type: integer
+                description: IPv4アドレスprefix長
+                example: 0
     # handler.postApplication, handler.getApplication, handler.patchApplicationの共通化
     Application:
       type: object


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

#43 

### このPRはどういう変更を行いますか？

* openapi.yaml にパケットフィルタAPIに関する仕様を追加します。
* ~~`Application` の必須フィールド(?)とおぼしき `resource_id` を追加します。~~
  - ~~このフィールドがないとデコードエラーが発生します。コードを編集するよりもスキーマを修正すべきと判断しました。~~ (本件については別途イシューを立てます)

ogenによるコード生成の再現性が担保できないと判断したため、仕様のみを更新し、クライアントの生成は実施していません。
クライアントの生成も含めて対応が必要な場合はご一報ください。

### ドキュメントの変更は必要ですか？

不要です。（API利用例を追加したい場合には必要です。)


### 備考

#38 などと同一のファイルを修正します。従ってマージ前に競合する変更の解決が必要になる可能性があります。